### PR TITLE
Update azurerm provider version to >= 4.12.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,3 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    ignore:
-      - dependency-name: "hashicorp/azurerm"
-        versions: ">= 4.x"

--- a/examples/storage-account-premium-blockblob/providers.tf
+++ b/examples/storage-account-premium-blockblob/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = "=3.116.0"
+      version = ">=4.12.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/storage-account-premium-fileshare/providers.tf
+++ b/examples/storage-account-premium-fileshare/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = "=3.116.0"
+      version = ">=4.12.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/storage-account-standard-blob/providers.tf
+++ b/examples/storage-account-standard-blob/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = "=3.116.0"
+      version = ">=4.12.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/storage-account-standard-queue/providers.tf
+++ b/examples/storage-account-standard-queue/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = "=3.116.0"
+      version = ">=4.12.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/storage-account-standard-storagev2/providers.tf
+++ b/examples/storage-account-standard-storagev2/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = "=3.116.0"
+      version = ">=4.12.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/storage-account-standard-table/providers.tf
+++ b/examples/storage-account-standard-table/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = "=3.116.0"
+      version = ">=4.12.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/storage-account-with-network-rule/providers.tf
+++ b/examples/storage-account-with-network-rule/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = "=3.116.0"
+      version = ">=4.12.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/providers.tf
+++ b/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "registry.terraform.io/hashicorp/azurerm"
-      version = "=3.116.0"
+      version = ">=4.12.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Fixes #18

Update `azurerm` provider version to `>=4.12.0` in multiple files.

* **Provider Version Update**
  - Update `azurerm` provider version to `>=4.12.0` in `examples/storage-account-premium-blockblob/providers.tf`, `examples/storage-account-premium-fileshare/providers.tf`, `examples/storage-account-standard-blob/providers.tf`, `examples/storage-account-standard-queue/providers.tf`, `examples/storage-account-standard-storagev2/providers.tf`, `examples/storage-account-standard-table/providers.tf`, `examples/storage-account-with-network-rule/providers.tf`, and `providers.tf`.

* **Dependabot Configuration**
  - Remove the ignore rule for `azurerm` versions `>= 4.x` in `.github/dependabot.yml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Insight-NA/modcloud-terraform-azure-storage/pull/19?shareId=e09f0166-0c4a-4c50-9b93-f67520ba349b).