### PR TITLE
Fix identity_ids handling in azurerm_storage_account resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ resource "azurerm_storage_account" "this" {
     for_each = var.identity == null ? [] : [var.identity]
     content {
       type         = identity.value.type
-      identity_ids = toset(values(identity.value.identity_ids))
+      identity_ids = identity.value.identity_ids != null ? toset(values(identity.value.identity_ids)) : null
     }
   }
   dynamic "immutability_policy" {


### PR DESCRIPTION
Related to #23

Add a null check for `identity.value.identity_ids` in `main.tf` to avoid errors when the value is null.

* Update the `identity_ids` parameter to handle null values by using a conditional expression.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Insight-NA/modcloud-terraform-azure-storage/pull/24?shareId=a6d40848-15bf-4afb-b4e9-8d2e3cb2434a).